### PR TITLE
Create JBNUscripts/find-cpu-spinning-all.sh

### DIFF
--- a/JBNUscripts/find-cpu-spinning-all.sh
+++ b/JBNUscripts/find-cpu-spinning-all.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+servers="com01 com02 com03 gpu01 gpu02"
+result=""
+for server in $servers
+do
+
+	temp=`sshpass -p 0slab ssh $server -tt -p 3932 < ~/find-cpu-spinning-single-node.sh | sed -n '/^'$server'/p'`
+	result="$result$temp"
+
+done
+TZ=Asia/Seoul date
+printf "%-10s\t%-10s\t%-17s\t%-36s\t%-30s\t%-20s\t%s\n" "HOSTNAME" "%CPU" "NAME" "UUID" "NOVA:NAME" "USER" "PROJECT"
+echo "$result"


### PR DESCRIPTION
모든 노드에 대하여 CPU 사용량이 100% 이상인 인스턴스의 정보를 출력하는 스크립트
JBNUscripts/find-cpu-spinning-single-node.sh 파일에 의존한다